### PR TITLE
Use dylib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 mruby/
-vendor/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_install:
   - sudo apt-get -qq update
 install:
   - sudo apt-get -qq install rake bison git gperf
+  - sudo apt-get -qq install libargtable2-dev
 script:
   - rake test
 notifications:

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -4,5 +4,5 @@ MRuby::Gem::Specification.new('mruby-argtable') do |spec|
   spec.license = 'BSD'
   spec.authors = ["Uchio Kondo", "Stewart Heitmann"]
 
-  spec.linker.libraries << 'argtable'
+  spec.linker.libraries << 'argtable2'
 end

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -4,36 +4,5 @@ MRuby::Gem::Specification.new('mruby-argtable') do |spec|
   spec.license = 'BSD'
   spec.authors = ["Uchio Kondo", "Stewart Heitmann"]
 
-  def spec.bundle_argtable
-    argtable_dir = "#{build.build_dir}/vendor/argtable3"
-    argtable_lib = libfile "#{argtable_dir}/.libs"
-    argtable_objs_dir = "#{argtable_dir}/.objs"
-    header = "#{argtable_dir}/argtable3.h"
-
-    task :clean do
-      FileUtils.rm_rf [argtable_dir]
-    end
-
-    file header do
-      sh "mkdir -p #{File.dirname(argtable_dir)}"
-      sh "test -d #{argtable_dir} && rm -rf #{argtable_dir} || true"
-      sh "git clone https://github.com/argtable/argtable3.git #{argtable_dir}"
-    end
-
-    file "#{argtable_objs_dir}/argtable3.o" => header do
-      sh "mkdir -p #{argtable_objs_dir}"
-      Dir.chdir argtable_dir do
-        puts "Command: #{build.cc.command} -c #{build.cc.flags.join(' ')} *.c -o #{argtable_objs_dir}/argtable3.o"
-        sh "#{build.cc.command} -c #{build.cc.flags.join(' ')} *.c -o #{argtable_objs_dir}/argtable3.o"
-      end
-    end
-
-    libmruby_a = libfile("#{build.build_dir}/lib/libmruby")
-    file libmruby_a => "#{argtable_objs_dir}/argtable3.o"
-
-    self.objs << "#{argtable_objs_dir}/argtable3.o"
-    self.cc.include_paths << argtable_dir
-  end
-
-  spec.bundle_argtable
+  spec.linker.libraries << 'argtable'
 end

--- a/src/mrb_argtable.c
+++ b/src/mrb_argtable.c
@@ -15,7 +15,7 @@
 #include "mruby/error.h"
 #include "mruby/value.h"
 #include "mrb_argtable.h"
-#include "argtable3.h"
+#include "argtable2.h"
 
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
- Using argtable2 (I've just been using compatible APIs).
- Pre-require `libargtable2` as package, so stopped checking out repo.

If we want to use statis linked argtable3, just are able to use [`static-link-argtable3`](https://github.com/udzura/mruby-argtable/tree/static-link-argtable3) branch:

``` ruby
  conf.gem github: 'udzura/mruby-argtable', branch: 'static-link-argtable3'
```
