### PR TITLE
Fix build failed in branch "static-link-argtable3"

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -18,6 +18,7 @@ MRuby::Gem::Specification.new('mruby-argtable') do |spec|
       unless File.exist? argtable_dir(build)
         sh "mkdir -p #{File.dirname(argtable_dir(build))}"
         sh "git clone https://github.com/argtable/argtable3.git #{argtable_dir(build)}"
+        sh "cd #{argtable_dir(build)}/tools && ./build dist && cd ../ && cp dist/argtable3.* ."
       end
     end
 


### PR DESCRIPTION
[argtable/argtable3](https://github.com/argtable/argtable3) no longer provide the amalgamation source code from v3.1.0 (argtable3.c and argtable3.h)
https://github.com/argtable/argtable3/releases/tag/v3.1.0

They instead provide script "tools/build" to generate amalgamation source and header file.

https://github.com/argtable/argtable3#quick-start

I confirmed build succeeded. See https://travis-ci.org/unasuke/mruby-argtable/builds/518569222